### PR TITLE
fix: deadlock in StopFetch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test: stop
 	docker compose -f docker-compose.yml up -d simavs-sync
 	sleep 3
 	docker ps -a
-	trap '$(STOP)' EXIT; go test ./... --timeout=10m
+	trap '$(STOP)' EXIT; go test ./... --timeout=10m --race
 .PHONY: test
 
 run-db-mongo:

--- a/rpcclient/arbitrum/client_test.go
+++ b/rpcclient/arbitrum/client_test.go
@@ -1,4 +1,4 @@
-package optimism
+package arbitrum
 
 import (
 	"testing"
@@ -14,7 +14,6 @@ func TestErrorHandling(t *testing.T) {
 		L1RPCURL:           "http://localhost:8545",
 		BeaconURL:          "http://localhost:8545",
 		BatchInbox:         common.Address{}.Hex(),
-		BatchSender:        common.Address{}.Hex(),
 		ConcurrentFetchers: 4,
 	}
 	client, err := NewClient(cfg)


### PR DESCRIPTION
## Context

Fix the deadlock, the bug case:
If the `BatchHeaders` is full, the fetcher is locked in the channel pushing, it never touch the `ctx.Done()` even `StopFetch` triggers.


<!-- Add a description of the changes that this PR introduces. -->

---

## Reviewers

- @mastereng12 
- @kashishshah 