### PR TITLE
fix: the pruning batch logic to avoid the previous batch removing

### DIFF
--- a/rpcclient/arbitrum/batch_fetcher.go
+++ b/rpcclient/arbitrum/batch_fetcher.go
@@ -140,7 +140,7 @@ func (f *Fetcher) Fetch(l1BeginBlockNumber uint64) error {
 			if err != nil {
 				return err
 			}
-			telemetry.MeasureSince(ti, "rpc_arbitrum", "l1_filter_logs")
+			telemetry.MeasureSince(ti, "rpc", "l1_filter_logs")
 
 			// sort the batches by L1 block number and L1 tx index
 			sort.Slice(batches, func(i, j int) bool {
@@ -183,7 +183,7 @@ func (f *Fetcher) Fetch(l1BeginBlockNumber uint64) error {
 // The range is [start, end].
 func (f *Fetcher) getL2BlockHashes(start, end uint64) ([]*sequencerv2types.BlockHeader, error) {
 	ti := time.Now()
-	defer telemetry.MeasureSince(ti, "rpc_arbitrum", "fetch_l2_block_hashes")
+	defer telemetry.MeasureSince(ti, "rpc", "fetch_l2_block_hashes")
 
 	g, ctx := errgroup.WithContext(context.Background())
 	g.SetLimit(f.concurrentFetcher)
@@ -300,7 +300,7 @@ func (f *Fetcher) fetchBlock(blockNumber uint64, txHash common.Hash) ([]byte, er
 			logger.Errorf("failed to get blobs: %v", err)
 			return nil, err
 		}
-		telemetry.MeasureSince(ti, "rpc_arbitrum", "fetch_beacon_blobs")
+		telemetry.MeasureSince(ti, "rpc", "fetch_beacon_blobs")
 		if len(blobs) != len(hashes) {
 			logger.Errorf("blobs length is not matched: %d, %d", len(blobs), len(hashes))
 			return nil, fmt.Errorf("blobs length is not matched: %d, %d", len(blobs), len(hashes))

--- a/rpcclient/mock/client.go
+++ b/rpcclient/mock/client.go
@@ -97,7 +97,10 @@ func (c *Client) NextBatch() (*sequencerv2types.BatchHeader, error) {
 		}
 	}
 
+	c.mtx.Lock()
 	c.fromL1BlockNumber++
+	c.mtx.Unlock()
+
 	return &sequencerv2types.BatchHeader{
 		BatchNumber: blockHeader.Number.Uint64(),
 		ChainId:     c.chainID,

--- a/rpcclient/mock/client.go
+++ b/rpcclient/mock/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -20,6 +21,7 @@ var _ types.RpcClient = (*Client)(nil)
 type Client struct {
 	evmclient.Client
 
+	mtx               sync.Mutex
 	fromL1BlockNumber uint64
 
 	chainID uint32
@@ -64,13 +66,17 @@ func (c *Client) GetFinalizedBlockNumber() (uint64, error) {
 
 // SetBeginBlockNumber sets the begin L1 & L2 block number.
 func (c *Client) SetBeginBlockNumber(l1BlockNumber uint64) bool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 	c.fromL1BlockNumber = l1BlockNumber
 	return true
 }
 
 // NextBatch returns the next batch after SetBeginBlockNumber.
 func (c *Client) NextBatch() (*sequencerv2types.BatchHeader, error) {
+	c.mtx.Lock()
 	l2BlockNumber := c.fromL1BlockNumber
+	c.mtx.Unlock()
 	blockHeader, err := c.GetBlockHeaderByNumber(l2BlockNumber, common.Hash{})
 	if err != nil {
 		if errors.Is(err, types.ErrNoResult) {

--- a/rpcclient/optimism/batch_fetcher.go
+++ b/rpcclient/optimism/batch_fetcher.go
@@ -198,7 +198,7 @@ func (f *Fetcher) Fetch(l1BeginBlockNumber uint64) error {
 			if err := g.Wait(); err != nil {
 				return err
 			}
-			telemetry.MeasureSince(ti, "rpc_optimism", "fetch_l1_blocks")
+			telemetry.MeasureSince(ti, "rpc", "fetch_l1_blocks")
 			framesRefs := make([]*FramesRef, 0)
 			m.Range(func(_, ref interface{}) bool {
 				framesRefs = append(framesRefs, ref.(*FramesRef))
@@ -222,7 +222,7 @@ func (f *Fetcher) Fetch(l1BeginBlockNumber uint64) error {
 // The range is [start, end].
 func (f *Fetcher) getL2BlockHashes(start, end uint64) ([]*sequencerv2types.BlockHeader, error) {
 	ti := time.Now()
-	defer telemetry.MeasureSince(ti, "rpc_arbitrum", "fetch_l2_block_hashes")
+	defer telemetry.MeasureSince(ti, "rpc", "fetch_l2_block_hashes")
 
 	g, ctx := errgroup.WithContext(context.Background())
 	g.SetLimit(f.concurrentFetcher)
@@ -363,7 +363,7 @@ func (f *Fetcher) fetchBlock(blockNumber uint64) ([]*FramesRef, error) {
 			logger.Errorf("failed to get blobs: %v", err)
 			return nil, err
 		}
-		telemetry.MeasureSince(ti, "rpc_optimism", "fetch_beacon_blobs")
+		telemetry.MeasureSince(ti, "rpc", "fetch_beacon_blobs")
 		if len(blobs) != len(hashes) {
 			logger.Errorf("blobs length is not matched: %d, %d", len(blobs), len(hashes))
 			return nil, fmt.Errorf("blobs length is not matched: %d, %d", len(blobs), len(hashes))

--- a/store/goleveldb/db.go
+++ b/store/goleveldb/db.go
@@ -93,8 +93,8 @@ func (d *DB) Prune(prefix []byte) error {
 	defer iter.Release()
 
 	iter.Seek(prefix)
-	iter.Prev()
-	for ; iter.Valid(); iter.Prev() {
+	iter.Prev() // Skip the last key-value pair with the prefix.
+	for iter.Prev(); iter.Valid(); iter.Prev() {
 		key := iter.Key()
 
 		if err := d.db.Delete(key, &opt.WriteOptions{Sync: true}); err != nil {

--- a/store/goleveldb/db_test.go
+++ b/store/goleveldb/db_test.go
@@ -47,7 +47,7 @@ func TestGoLevelDB(t *testing.T) {
 	require.Equal(t, 4, count)
 
 	// prune
-	require.NoError(t, db.Prune([]byte("key1")))
+	require.NoError(t, db.Prune([]byte("key2")))
 	_, err = db.Get([]byte("key1"))
 	require.NoError(t, err)
 	_, err = db.Get([]byte("key"))


### PR DESCRIPTION
## Context

Closes: #434 

<!-- Add a description of the changes that this PR introduces. -->

- fix the panic of `nil` access in the `verifyCommittee`

---

## Reviewers

- @mastereng12 
- @kashishshah 