### PR TITLE
fix: getBatch with L1TxIndex

### DIFF
--- a/network/client_test.go
+++ b/network/client_test.go
@@ -118,12 +118,17 @@ func TestClientStorage(t *testing.T) {
 	require.Equal(t, uint64(8), prev)
 
 	// get batch by L1 block number
-	_, err = client.getBatchHeader(3, 2)
+	_, err = client.getBatchHeader(3, 2, 0)
 	require.Error(t, err)
-	batch, err := client.getBatchHeader(5, 5)
+	batch, err := client.getBatchHeader(5, 5, 1)
 	require.NoError(t, err)
 	require.Equal(t, uint64(5), batch.L1BlockNumber)
 	require.Equal(t, uint32(1), batch.L1TxIndex)
+	_, err = client.getBatchHeader(5, 5, 2)
+	require.Error(t, err)
+	batch, err = client.getBatchHeader(8, 8, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(8), batch.L1BlockNumber)
 
 	// init begin block number
 	err = client.initBeginBlockNumber(5)


### PR DESCRIPTION
## Context

The issue is appeared in devnet when there are two batches with same L1BlockNumber and L2BlockNumber. To ensure distinguish them, refactor the `getBatchHeader` with `L1TxIndex`.

<!-- Add a description of the changes that this PR introduces. -->

---

## Reviewers

- @mastereng12 
- @kashishshah 