### PR TITLE
refactor: modify the batch merkle structure

### DIFF
--- a/crypto/merkle.go
+++ b/crypto/merkle.go
@@ -14,7 +14,7 @@ func MerkleRoot(data [][]byte) []byte {
 		return utils.Hash([]byte{})
 	}
 
-	emptyLeaf := leafHash([]byte{})
+	emptyLeaf := make([]byte, 32)
 	// expand the leaf nodes to a power of 2
 	count := nextPowerOfTwo(len(data))
 	nodes := make([][]byte, 0, count)

--- a/crypto/merkle_test.go
+++ b/crypto/merkle_test.go
@@ -2,9 +2,11 @@ package crypto
 
 import (
 	"bytes"
+	"math/big"
 	"testing"
 
 	"github.com/Lagrange-Labs/lagrange-node/utils"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestNextPowerOfTwo(t *testing.T) {
@@ -79,5 +81,31 @@ func TestMerkleRoot(t *testing.T) {
 		if got := MerkleRoot(tc.data); !bytes.Equal(got, utils.Hex2Bytes(tc.expected)) {
 			t.Errorf("MerkleRoot(%x) = %x; expected %v", tc.data, got, tc.expected)
 		}
+	}
+}
+
+func TestRootWithCommittee(t *testing.T) {
+	committee := []struct {
+		operator    string
+		votingPower uint64
+		publicKey   string
+	}{
+		{"0xFc4AC3204E0458967b758c902BcBBB88A3B7582f", 100, "2d6c60e91f6f4026d3637018d1b66636090a16ace9595d52e01381649f5a8bfb086ce92c7caece1b8efad25e5e23332771080c87c38ebe2805cd57d008980693"},
+		{"0x03fbBE0CAe10ea5fe1D9E9a37b57F719574B48D4", 100, "0dae9aed87b0ff66b31048db9e82093c0288c1c20f197501ba1fb53b60aba57c1bb9d89335453c4516dc6c347949c9cfcb0cc1158ffb43204cd0912e3443dd76"},
+		{"0x4736933A5B78C6fEba7635Bc57117f758c34d424", 100, "2b67946b6e46b37d20e0c5ce176510853fcc1a4c1f07764b151c83cc0da17ac92dbaf767b87e784aecec6eb6f381f92bf4e644c811d2d7bf9f1de5a605cf5e77"},
+	}
+
+	leaves := make([][]byte, 0, len(committee))
+	for _, c := range committee {
+		res := make([]byte, 0, 32+32+20+12)
+		res = append(res, utils.Hex2Bytes(c.publicKey)...)
+		res = append(res, utils.Hex2Bytes(c.operator)...)
+		res = append(res, common.LeftPadBytes(big.NewInt(int64(c.votingPower)).Bytes(), 12)...)
+		leaves = append(leaves, res)
+	}
+	root := MerkleRoot(leaves)
+	expected := "2d64f451e549526f76e0e6b9cf724c229298998b2d9fdfa0d96efbf862685915"
+	if !bytes.Equal(root, utils.Hex2Bytes(expected)) {
+		t.Errorf("MerkleRoot(%v) = %x; expected %v", leaves, root, expected)
 	}
 }


### PR DESCRIPTION
## Context

- To share the same merkle tree between Committee and Batch

<!-- Add a description of the changes that this PR introduces. -->

---

## Reviewers

- @cool-develope 
- @kashishshah 